### PR TITLE
fix: harden bridge reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,36 @@ All options can be set via constructor or environment variable:
 
 ---
 
+## How does this compare to other AI proxy solutions?
+
+| Feature | claude-code-bridge | LiteLLM | Cloudflare AI Gateway | Kong AI Gateway | LocalAI | Ollama | vLLM | Portkey |
+|---|---|---|---|---|---|---|---|---|
+| **What it is** | OAuth token bridge | Open-source gateway | Managed edge service | Enterprise gateway | Local inference | Local inference | GPU serving engine | Enterprise LLMOps |
+| **Multi-provider** | No (Anthropic only) | Yes (100+) | Yes (7+) | Yes (10+) | N/A (local models) | N/A (local models) | N/A (local models) | Yes (200+) |
+| **Auth handling** | Claude Code OAuth token | Virtual keys | Cloudflare tokens | Kong auth plugins | None (local) | None (local) | None (local) | Centralized mgmt |
+| **Setup complexity** | Very low | Medium | Low | High | Low | Very low | Medium | High |
+| **Runs locally** | Yes | Yes | No (cloud) | No (cloud) | Yes | Yes | Yes | No (cloud) |
+| **Cost tracking** | No | Yes | Yes | No | N/A | N/A | N/A | Yes |
+| **Production ready** | No (dev only) | Yes | Yes | Yes | Limited | Limited | Yes | Yes |
+| **Rate limiting** | No | Yes | Yes (edge) | Yes | Via proxy | Via proxy | Via proxy | Yes |
+| **License** | MIT | Open source | Commercial | Open source | Open source | Open source | Open source | Commercial |
+
+### When to use what
+
+- **claude-code-bridge** — You already have a Claude Code subscription and want zero-config AI calls from your local scripts during development. No API key, no billing, no setup. Unique in that it piggybacks on an existing subscription's OAuth token.
+- **LiteLLM** — You need to call multiple AI providers (OpenAI, Anthropic, Gemini, etc.) through a single unified API. Best open-source option with cost tracking and load balancing.
+- **Cloudflare AI Gateway** — You want a managed, production-grade gateway with global edge caching and zero infrastructure to maintain.
+- **Kong AI Gateway** — Your organization already uses Kong for API management and wants to add AI routing to the existing stack.
+- **LocalAI / Ollama** — You want to run models entirely on your own hardware with no external API calls. Great for privacy and offline use, but limited to open-source model quality.
+- **vLLM** — You need high-performance GPU-accelerated inference for local models at scale.
+- **Portkey** — You're in a regulated industry (HIPAA, SOC 2) and need full compliance, observability, and cost analytics across 200+ LLMs.
+
+### Key differentiator
+
+Every other solution requires either its own API keys (with separate billing) or runs local models. claude-code-bridge is the only one that reuses your existing Claude Code subscription with no additional cost or credentials. The trade-off is that it only works during local development while Claude Code is running.
+
+---
+
 ## Notes for AI coding assistants
 
 If you are an AI assistant (Cursor, Copilot, Aider, etc.) helping a developer integrate this package:

--- a/index.js
+++ b/index.js
@@ -24,16 +24,24 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import express   from 'express';
+import { readFileSync } from 'node:fs';
+import { resolve }      from 'node:path';
 
-const DEFAULT_MODEL = 'claude-opus-4-5';
-const DEFAULT_PORT  = 3099;
+const DEFAULT_MODEL      = 'claude-opus-4-5';
+const DEFAULT_PORT       = 3099;
+const DEFAULT_TIMEOUT_MS = 120_000;
+const MAX_TOKENS_LIMIT   = 8192;
+const RETRY_DELAY_MS     = 1000;
+const RETRYABLE_STATUSES = new Set([429, 529]);
 
 /**
  * @param {{
- *   port?:      number,   // default 3099 (or $PORT)
- *   model?:     string,   // default 'claude-opus-4-5' (or $BRIDGE_MODEL)
- *   corsOrigin?: RegExp,  // default /^http:\/\/localhost(:\d+)?$/
- *   verbose?:   boolean,  // print startup banner, default true
+ *   port?:       number,   // default 3099 (or $PORT)
+ *   model?:      string,   // default 'claude-opus-4-5' (or $BRIDGE_MODEL)
+ *   corsOrigin?: RegExp,   // default /^http:\/\/localhost(:\d+)?$/
+ *   verbose?:    boolean,  // print startup banner, default true
+ *   timeoutMs?:  number,   // API call timeout, default 120000
+ *   envPath?:    string,   // path to .env file, default '.env' (cwd-relative)
  * }} [options]
  *
  * @returns {{ app: import('express').Express, start: () => Promise<import('http').Server> }}
@@ -44,12 +52,25 @@ export function createBridge(options = {}) {
     model      = process.env.BRIDGE_MODEL        ?? DEFAULT_MODEL,
     corsOrigin = /^http:\/\/localhost(:\d+)?$/,
     verbose    = true,
+    timeoutMs  = DEFAULT_TIMEOUT_MS,
+    envPath    = resolve(process.cwd(), '.env'),
   } = options;
 
   // ── Token access ─────────────────────────────────────────────────────────────
-  // Token rotates each Claude Code session; always read live from env.
+  // Reads the .env file from disk on every call so token rotations are
+  // picked up without restarting the server.
+  function readTokenFromDisk() {
+    try {
+      const contents = readFileSync(envPath, 'utf8');
+      const match = contents.match(/^CLAUDE_CODE_OAUTH_TOKEN=(.+)$/m);
+      return match?.[1]?.trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
   function getToken() {
-    const t = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    const t = readTokenFromDisk() || process.env.CLAUDE_CODE_OAUTH_TOKEN;
     if (!t) throw new Error(
       'CLAUDE_CODE_OAUTH_TOKEN is not set.\n' +
       'Make sure the Claude Code hook is writing it to .env — see README.'
@@ -92,32 +113,61 @@ export function createBridge(options = {}) {
    * Response: { text: string, model: string, elapsed_ms: number }
    */
   app.post('/generate', async (req, res) => {
-    const { systemPrompt, userPrompt, model: reqModel, maxTokens = 1024 } = req.body;
+    const { systemPrompt, userPrompt, model: reqModel, maxTokens: rawMaxTokens = 1024 } = req.body;
 
-    if (!userPrompt) {
-      return res.status(400).json({ error: '`userPrompt` is required' });
+    if (!userPrompt || typeof userPrompt !== 'string') {
+      return res.status(400).json({ error: '`userPrompt` is required and must be a string' });
     }
 
+    if (reqModel !== undefined && (typeof reqModel !== 'string' || reqModel.trim() === '')) {
+      return res.status(400).json({ error: '`model` must be a non-empty string' });
+    }
+
+    const maxTokens = Math.max(1, Math.min(MAX_TOKENS_LIMIT, Math.floor(Number(rawMaxTokens) || 1024)));
     const useModel = reqModel ?? model;
     const t0 = Date.now();
 
-    try {
+    async function attemptGenerate(signal) {
       const anthropic = getClient();
-      const msg = await anthropic.messages.create({
+      return anthropic.messages.create({
         model:      useModel,
         max_tokens: maxTokens,
         ...(systemPrompt ? { system: systemPrompt } : {}),
         messages: [{ role: 'user', content: userPrompt }],
-      });
+      }, { signal });
+    }
+
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+      let msg;
+      try {
+        msg = await attemptGenerate(controller.signal);
+      } catch (err) {
+        // Retry once for transient errors
+        if (RETRYABLE_STATUSES.has(err.status) && !controller.signal.aborted) {
+          if (verbose) console.log(`[bridge] ${err.status} — retrying in ${RETRY_DELAY_MS}ms...`);
+          await new Promise(r => setTimeout(r, RETRY_DELAY_MS));
+          msg = await attemptGenerate(controller.signal);
+        } else {
+          throw err;
+        }
+      } finally {
+        clearTimeout(timer);
+      }
 
       const text = msg.content[0]?.text ?? '';
       res.json({ text, model: useModel, elapsed_ms: Date.now() - t0 });
 
     } catch (err) {
-      const status = err.status ?? 500;
-      if (verbose) console.error('[bridge] /generate error:', err.message);
+      const status = err.name === 'AbortError' ? 504 : (err.status ?? 500);
+      const message = err.name === 'AbortError'
+        ? `Request timed out after ${timeoutMs}ms`
+        : err.message;
+      if (verbose) console.error('[bridge] /generate error:', message);
       res.status(status).json({
-        error:      err.message,
+        error:      message,
         model:      useModel,
         elapsed_ms: Date.now() - t0,
       });
@@ -126,7 +176,7 @@ export function createBridge(options = {}) {
 
   // ── GET /health ───────────────────────────────────────────────────────────────
   app.get('/health', (_req, res) => {
-    const token = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    const token = readTokenFromDisk() || process.env.CLAUDE_CODE_OAUTH_TOKEN;
     res.json({
       ok:          !!token,
       authReady:   !!token,
@@ -135,14 +185,21 @@ export function createBridge(options = {}) {
     });
   });
 
+  // ── JSON parse error handler ────────────────────────────────────────────────
+  app.use((err, _req, res, _next) => {
+    if (err.type === 'entity.parse.failed') {
+      return res.status(400).json({ error: 'Invalid JSON in request body' });
+    }
+    if (verbose) console.error('[bridge] Unhandled error:', err.message);
+    res.status(500).json({ error: 'Internal server error' });
+  });
+
   // ── start() ──────────────────────────────────────────────────────────────────
   function start() {
     return new Promise((resolve, reject) => {
-      const server = app.listen(port, (err) => {
-        if (err) return reject(err);
-
+      const server = app.listen(port, () => {
         if (verbose) {
-          const token = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+          const token = readTokenFromDisk() || process.env.CLAUDE_CODE_OAUTH_TOKEN;
           console.log('\n╔══════════════════════════════════════════════════╗');
           console.log('║  claude-code-bridge                              ║');
           console.log('╚══════════════════════════════════════════════════╝');
@@ -151,6 +208,7 @@ export function createBridge(options = {}) {
             ? `✓ token present (${token.slice(0, 16)}...)`
             : '✗ CLAUDE_CODE_OAUTH_TOKEN missing — see README'}`);
           console.log(`  Model    : ${model}`);
+          console.log(`  Timeout  : ${timeoutMs}ms`);
           console.log('\n  Endpoints:');
           console.log('    POST /generate   { systemPrompt?, userPrompt, model?, maxTokens? }');
           console.log('    GET  /health     → { ok, authReady, model, tokenPrefix }\n');

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "local-bridge",
     "ai"
   ],
+  "engines": {
+    "node": ">=20.6.0"
+  },
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/server.js
+++ b/server.js
@@ -8,4 +8,22 @@
 import { createBridge } from './index.js';
 
 const { start } = createBridge();
-await start();
+const server = await start();
+
+// ── Graceful shutdown ──────────────────────────────────────────────────────────
+function shutdown(signal) {
+  console.log(`\n[bridge] ${signal} received — shutting down gracefully...`);
+  server.close(() => {
+    console.log('[bridge] All connections closed. Goodbye.');
+    process.exit(0);
+  });
+
+  // Force exit after 5 seconds if connections don't close
+  setTimeout(() => {
+    console.error('[bridge] Forced shutdown after timeout.');
+    process.exit(1);
+  }, 5000).unref();
+}
+
+process.on('SIGINT',  () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));


### PR DESCRIPTION
## Summary
- **Critical fix**: Token was loaded once at startup and never refreshed — now reads `.env` from disk on every request so token rotations work without restart
- Adds request timeout (120s), retry for transient 429/529 errors, input validation, JSON error handling, and graceful shutdown
- Fixes dead code in `app.listen` callback (Express doesn't pass `err`)
- Adds `engines` field requiring Node.js >=20.6.0
- Adds proxy solution comparison table to README (vs LiteLLM, Cloudflare, Kong, etc.)

## Test plan
- [ ] `npm start` — server starts cleanly
- [ ] `GET /health` — shows token info
- [ ] Change token in `.env` while server runs, `GET /health` again — reflects new token (verifies dynamic refresh)
- [ ] `POST /generate` with missing `userPrompt` — clean 400 error
- [ ] `POST /generate` with malformed JSON — clean 400 error
- [ ] `POST /generate` with valid request — works
- [ ] Ctrl+C — graceful shutdown message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)